### PR TITLE
Allow to not create wrapper element in i18n component

### DIFF
--- a/__tests__/vue/component.spec.ts
+++ b/__tests__/vue/component.spec.ts
@@ -318,4 +318,54 @@ describe('component', () => {
     expect(mounted.get('strong')).toBeTruthy()
     expect(mounted.html()).toEqual('<span><span>Test <span class="inner"> Inner <strong class="strong">strong</strong> </span></span></span>')
   })
+
+  it('can work with tag=false', async () => {
+    // Arrange
+    bundle.addResource(
+      new FluentResource(ftl`
+      key = Hello {$name}
+      `),
+    )
+
+    const component = {
+      data() {
+        return {
+          name: 'John',
+        }
+      },
+      template: `
+        <i18n path="key" :args="{ name }" :tag="false"></i18n>`,
+    }
+
+    // Act
+    const mounted = mountWithFluent(fluent, component)
+
+    // Assert
+    expect(mounted.html()).toEqual('Hello \u{2068}John\u{2069}')
+  })
+
+  it('can work with no-tag', async () => {
+    // Arrange
+    bundle.addResource(
+      new FluentResource(ftl`
+      key = Hello {$name}
+      `),
+    )
+
+    const component = {
+      data() {
+        return {
+          name: 'John',
+        }
+      },
+      template: `
+        <i18n path="key" :args="{ name }" no-tag></i18n>`,
+    }
+
+    // Act
+    const mounted = mountWithFluent(fluent, component)
+
+    // Assert
+    expect(mounted.html()).toEqual('Hello \u{2068}John\u{2069}')
+  })
 })

--- a/__tests__/vue/component.spec.ts
+++ b/__tests__/vue/component.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isVue2, isVue3 } from 'vue-demi'
 
 import { FluentBundle, FluentResource } from '@fluent/bundle'
 import ftl from '@fluent/dedent'
@@ -319,12 +320,12 @@ describe('component', () => {
     expect(mounted.html()).toEqual('<span><span>Test <span class="inner"> Inner <strong class="strong">strong</strong> </span></span></span>')
   })
 
-  it('can work with tag=false', async () => {
+  it.runIf(isVue3)('can work with tag=false', async () => {
     // Arrange
     bundle.addResource(
       new FluentResource(ftl`
-      key = Hello {$name}
-      `),
+    key = Hello {$name}
+    `),
     )
 
     const component = {
@@ -344,12 +345,12 @@ describe('component', () => {
     expect(mounted.html()).toEqual('Hello \u{2068}John\u{2069}')
   })
 
-  it('can work with no-tag', async () => {
+  it.runIf(isVue3)('can work with no-tag', async () => {
     // Arrange
     bundle.addResource(
       new FluentResource(ftl`
-      key = Hello {$name}
-      `),
+    key = Hello {$name}
+    `),
     )
 
     const component = {
@@ -367,5 +368,37 @@ describe('component', () => {
 
     // Assert
     expect(mounted.html()).toEqual('Hello \u{2068}John\u{2069}')
+  })
+
+  it.runIf(isVue2)('warns when used with tag=false', async () => {
+    // Arrange
+    bundle.addResource(
+      new FluentResource(ftl`
+    key = Hello {$name}
+    `),
+    )
+
+    const component = {
+      data() {
+        return {
+          name: 'John',
+        }
+      },
+      template: `
+        <i18n path="key" :args="{ name }" :tag="false"></i18n>`,
+    }
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Act
+    const mounted = mountWithFluent(fluent, component)
+
+    // Assert
+    expect(mounted.html()).toEqual('')
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith('[fluent-vue] Vue 2 requires a root element when rendering components. Please, use `tag` prop to specify the root element.')
+
+    // Cleanup
+    warn.mockRestore()
   })
 })

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ls-lint": "ls-lint",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "node scripts/swap-vue.mjs 3 && vitest run",
-    "test:watch": "node scripts/swap-vue.mjs 3 && vitest",
+    "test:watch": "vitest",
     "test:2": "node scripts/swap-vue.mjs 2 && vitest run",
     "test:3": "node scripts/swap-vue.mjs 3 && vitest run",
     "prepare": "husky install",

--- a/scripts/swap-vue.mjs
+++ b/scripts/swap-vue.mjs
@@ -2,10 +2,10 @@ import { readFileSync, writeFileSync } from 'fs'
 import { execa } from 'execa'
 
 const vue3packages = {
-  'vue': 'npm:vue@^3.2.47',
+  'vue': 'npm:vue@^3.3.4',
   'vue-2': 'npm:vue@^2.7.14',
-  'vue-3': 'npm:vue@^3.2.47',
-  '@vue/compiler-sfc': '^3.2.47',
+  'vue-3': 'npm:vue@^3.3.4',
+  '@vue/compiler-sfc': '^3.3.4',
   '@vue/test-utils': '^2.3.2',
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export function createFluentVue(options: FluentVueOptions): FluentVue {
         vue2.directive(resolvedOptions.directiveName, createVue2Directive(rootContext))
       }
 
-      (vue as Vue).component(resolvedOptions.componentName, createComponent(resolvedOptions))
+      (vue as Vue).component(resolvedOptions.componentName, createComponent(resolvedOptions, rootContext))
     },
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { InstallFunction, Vue, Vue2, Vue3, Vue3Component } from './types/ty
 import type { TranslationWithAttrs } from './TranslationContext'
 import { TranslationContext } from './TranslationContext'
 import { createVue2Directive, createVue3Directive } from './vue/directive'
-import component from './vue/component'
+import { createComponent } from './vue/component'
 import { getContext } from './getContext'
 import { RootContextSymbol } from './symbols'
 import { resolveOptions } from './util/options'
@@ -51,30 +51,25 @@ export function createFluentVue(options: FluentVueOptions): FluentVue {
     formatWithAttrs: rootContext.formatWithAttrs.bind(rootContext),
 
     install(vue) {
-      const globalFormatName = options.globals?.functions?.format || '$t'
-      const globalFormatAttrsName = options.globals?.functions?.formatAttrs || '$ta'
-      const directiveName = options.globals?.directive || 't'
-      const componentName = options.globals?.component || 'i18n'
-
       if (isVue3) {
         const vue3 = vue as Vue3
 
         vue3.provide(RootContextSymbol, rootContext)
 
-        vue3.config.globalProperties[globalFormatName] = function (
+        vue3.config.globalProperties[resolvedOptions.globalFormatName] = function (
           key: string,
           value?: Record<string, FluentVariable>,
         ) {
           return getContext(rootContext, this as Vue3Component).format(key, value)
         }
-        vue3.config.globalProperties[globalFormatAttrsName] = function (
+        vue3.config.globalProperties[resolvedOptions.globalFormatAttrsName] = function (
           key: string,
           value?: Record<string, FluentVariable>,
         ) {
           return getContext(rootContext, this as Vue3Component).formatAttrs(key, value)
         }
 
-        vue3.directive(directiveName, createVue3Directive(rootContext))
+        vue3.directive(resolvedOptions.directiveName, createVue3Directive(rootContext))
       }
       else {
         const vue2 = vue as Vue2
@@ -87,17 +82,17 @@ export function createFluentVue(options: FluentVueOptions): FluentVue {
           },
         })
 
-        vue2.prototype[globalFormatName] = function (key: string, value?: Record<string, FluentVariable>) {
+        vue2.prototype[resolvedOptions.globalFormatName] = function (key: string, value?: Record<string, FluentVariable>) {
           return getContext(rootContext, this).format(key, value)
         }
-        vue2.prototype[globalFormatAttrsName] = function (key: string, value?: Record<string, FluentVariable>) {
+        vue2.prototype[resolvedOptions.globalFormatAttrsName] = function (key: string, value?: Record<string, FluentVariable>) {
           return getContext(rootContext, this).formatAttrs(key, value)
         }
 
-        vue2.directive(directiveName, createVue2Directive(rootContext))
+        vue2.directive(resolvedOptions.directiveName, createVue2Directive(rootContext))
       }
 
-      (vue as Vue).component(componentName, component)
+      (vue as Vue).component(resolvedOptions.componentName, createComponent(resolvedOptions))
     },
   }
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -23,11 +23,11 @@ export interface FluentVueOptions {
   }
 
   /**
-   * Tag name for the component.
+   * Tag name used in the `i18n` component.
    * Set to `false` to disable wrapping the translation in a tag.
    * @default 'span'
    */
-  tag?: string | false
+  componentTag?: string | false
 }
 
 export interface TranslationContextOptions {
@@ -40,5 +40,5 @@ export interface ResolvedOptions extends TranslationContextOptions {
   globalFormatAttrsName: string
   directiveName: string
   componentName: string
-  tag: string | false
+  componentTag: string | false
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -20,9 +20,25 @@ export interface FluentVueOptions {
     },
     component?: string
     directive?: string
-  }}
+  }
+
+  /**
+   * Tag name for the component.
+   * Set to `false` to disable wrapping the translation in a tag.
+   * @default 'span'
+   */
+  tag?: string | false
+}
 
 export interface TranslationContextOptions {
   warnMissing: (key: string) => void
   parseMarkup: (markup: string) => SimpleNode[]
+}
+
+export interface ResolvedOptions extends TranslationContextOptions {
+  globalFormatName: string
+  globalFormatAttrsName: string
+  directiveName: string
+  componentName: string
+  tag: string | false
 }

--- a/src/util/options.ts
+++ b/src/util/options.ts
@@ -1,4 +1,4 @@
-import type { FluentVueOptions, SimpleNode, TranslationContextOptions } from 'src/types'
+import type { FluentVueOptions, ResolvedOptions, SimpleNode } from 'src/types'
 
 import { assert, warn } from './warn'
 
@@ -25,9 +25,14 @@ function getWarnMissing(options: FluentVueOptions) {
     return options.warnMissing
 }
 
-export function resolveOptions(options: FluentVueOptions): TranslationContextOptions {
+export function resolveOptions(options: FluentVueOptions): ResolvedOptions {
   return {
     warnMissing: getWarnMissing(options),
     parseMarkup: options.parseMarkup ?? defaultMarkupParser,
+    globalFormatName: options.globals?.functions?.format ?? '$t',
+    globalFormatAttrsName: options.globals?.functions?.formatAttrs ?? '$ta',
+    directiveName: options.globals?.directive ?? 't',
+    componentName: options.globals?.component ?? 'i18n',
+    tag: options.tag ?? 'span',
   }
 }

--- a/src/util/options.ts
+++ b/src/util/options.ts
@@ -33,6 +33,6 @@ export function resolveOptions(options: FluentVueOptions): ResolvedOptions {
     globalFormatAttrsName: options.globals?.functions?.formatAttrs ?? '$ta',
     directiveName: options.globals?.directive ?? 't',
     componentName: options.globals?.component ?? 'i18n',
-    tag: options.tag ?? 'span',
+    componentTag: options.componentTag ?? 'span',
   }
 }

--- a/src/vue/component.ts
+++ b/src/vue/component.ts
@@ -31,6 +31,7 @@ export function createComponent(options: ResolvedOptions) {
       tag: { type: [String, Boolean] as PropType<string | false>, default: options.tag },
       args: { type: Object, default: () => ({}) },
       html: { type: Boolean, default: false },
+      noTag: { type: Boolean, default: false },
     },
     setup(props, { slots, attrs }) {
       const rootContext = inject(RootContextSymbol)
@@ -104,7 +105,7 @@ export function createComponent(options: ResolvedOptions) {
         return nodes.map(processNode)
       })
 
-      return () => props.tag === false ? children.value : h(props.tag, { ...attrs }, children.value)
+      return () => props.tag === false || props.noTag ? children.value : h(props.tag, { ...attrs }, children.value)
     },
   })
 }

--- a/src/vue/component.ts
+++ b/src/vue/component.ts
@@ -4,7 +4,6 @@ import {
   defineComponent,
   getCurrentInstance,
   h,
-  inject,
   isVue2,
 } from 'vue-demi'
 import type { ResolvedOptions, SimpleNode } from 'src/types'
@@ -12,8 +11,8 @@ import type { VueComponent } from 'src/types/typesCompat'
 
 import { camelize } from '../util/camelize'
 import { getContext } from '../getContext'
-import { RootContextSymbol } from '../symbols'
-import { assert, warn } from '../util/warn'
+import { warn } from '../util/warn'
+import type { TranslationContext } from '../TranslationContext'
 
 function getParentWithFluent(
   instance: VueComponent | null | undefined,
@@ -31,7 +30,7 @@ function getParentWithFluent(
 // &amp;, &#0038;, &#x0026;.
 const reMarkup = /<|&#?\w+;/
 
-export function createComponent(options: ResolvedOptions) {
+export function createComponent(options: ResolvedOptions, rootContext: TranslationContext) {
   return defineComponent({
     name: options.componentName,
     props: {
@@ -42,8 +41,6 @@ export function createComponent(options: ResolvedOptions) {
       noTag: { type: Boolean, default: false },
     },
     setup(props, { slots, attrs }) {
-      const rootContext = inject(RootContextSymbol)
-      assert(rootContext != null, 'i18n component used without installing plugin')
       const instance = getCurrentInstance()
       const parent = getParentWithFluent(instance?.proxy)
       const fluent = getContext(rootContext, parent)

--- a/src/vue/component.ts
+++ b/src/vue/component.ts
@@ -1,4 +1,12 @@
-import { type PropType, computed, defineComponent, getCurrentInstance, h, inject } from 'vue-demi'
+import {
+  type PropType,
+  computed,
+  defineComponent,
+  getCurrentInstance,
+  h,
+  inject,
+  isVue2,
+} from 'vue-demi'
 import type { ResolvedOptions, SimpleNode } from 'src/types'
 import type { VueComponent } from 'src/types/typesCompat'
 
@@ -104,6 +112,9 @@ export function createComponent(options: ResolvedOptions) {
         const nodes = fluent.options.parseMarkup(translation.value.value)
         return nodes.map(processNode)
       })
+
+      if (isVue2 && (props.tag === false || props.noTag))
+        warn('Vue 2 requires a root element when rendering components. Please, use `tag` prop to specify the root element.')
 
       return () => props.tag === false || props.noTag ? children.value : h(props.tag, { ...attrs }, children.value)
     },

--- a/src/vue/component.ts
+++ b/src/vue/component.ts
@@ -36,7 +36,7 @@ export function createComponent(options: ResolvedOptions) {
     name: options.componentName,
     props: {
       path: { type: String, required: true },
-      tag: { type: [String, Boolean] as PropType<string | false>, default: options.tag },
+      tag: { type: [String, Boolean] as PropType<string | false>, default: options.componentTag },
       args: { type: Object, default: () => ({}) },
       html: { type: Boolean, default: false },
       noTag: { type: Boolean, default: false },

--- a/src/vue/component.ts
+++ b/src/vue/component.ts
@@ -1,5 +1,5 @@
-import { computed, defineComponent, getCurrentInstance, h, inject } from 'vue-demi'
-import type { SimpleNode } from 'src/types'
+import { type PropType, computed, defineComponent, getCurrentInstance, h, inject } from 'vue-demi'
+import type { ResolvedOptions, SimpleNode } from 'src/types'
 import type { VueComponent } from 'src/types/typesCompat'
 
 import { camelize } from '../util/camelize'
@@ -23,86 +23,88 @@ function getParentWithFluent(
 // &amp;, &#0038;, &#x0026;.
 const reMarkup = /<|&#?\w+;/
 
-export default defineComponent({
-  name: 'i18n',
-  props: {
-    path: { type: String, required: true },
-    tag: { type: String, default: 'span' },
-    args: { type: Object, default: () => ({}) },
-    html: { type: Boolean, default: false },
-  },
-  setup(props, { slots, attrs }) {
-    const rootContext = inject(RootContextSymbol)
-    assert(rootContext != null, 'i18n component used without installing plugin')
-    const instance = getCurrentInstance()
-    const parent = getParentWithFluent(instance?.proxy)
-    const fluent = getContext(rootContext, parent)
+export function createComponent(options: ResolvedOptions) {
+  return defineComponent({
+    name: options.componentName,
+    props: {
+      path: { type: String, required: true },
+      tag: { type: [String, Boolean] as PropType<string | false>, default: options.tag },
+      args: { type: Object, default: () => ({}) },
+      html: { type: Boolean, default: false },
+    },
+    setup(props, { slots, attrs }) {
+      const rootContext = inject(RootContextSymbol)
+      assert(rootContext != null, 'i18n component used without installing plugin')
+      const instance = getCurrentInstance()
+      const parent = getParentWithFluent(instance?.proxy)
+      const fluent = getContext(rootContext, parent)
 
-    const translation = computed(() => {
-      const fluentParams = Object.assign(
-        {},
-        props.args,
-        // Create fake translation parameters for each slot.
-        // Later, we'll replace the parameters with the actual slot
-        ...Object.keys(slots).map(key => ({
-          [key]: `\uFFFF\uFFFE${key}\uFFFF`,
-        })),
-      )
-
-      const result = fluent.formatWithAttrs(props.path, fluentParams)
-
-      const camelizedAttrs = Object.fromEntries(
-        Object.entries(result.attributes).map(([key, value]) => [camelize(key), value]),
-      )
-
-      return {
-        value: result.value,
-        attributes: camelizedAttrs,
-      }
-    })
-
-    const insertSlots = (text: string | null) => {
-      return text?.split('\uFFFF')
-        .map(text =>
-          text.startsWith('\uFFFE')
-            ? slots[text.replace('\uFFFE', '')]!(translation.value.attributes)
-            : text,
+      const translation = computed(() => {
+        const fluentParams = Object.assign(
+          {},
+          props.args,
+          // Create fake translation parameters for each slot.
+          // Later, we'll replace the parameters with the actual slot
+          ...Object.keys(slots).map(key => ({
+            [key]: `\uFFFF\uFFFE${key}\uFFFF`,
+          })),
         )
-    }
 
-    // No way to type this properly, so we'll just use `any` for now.
-    const processNode = (node: SimpleNode): any => {
-      if (node.nodeType === 3) { // Node.TEXT_NODE
-        return insertSlots(node.nodeValue)
+        const result = fluent.formatWithAttrs(props.path, fluentParams)
+
+        const camelizedAttrs = Object.fromEntries(
+          Object.entries(result.attributes).map(([key, value]) => [camelize(key), value]),
+        )
+
+        return {
+          value: result.value,
+          attributes: camelizedAttrs,
+        }
+      })
+
+      const insertSlots = (text: string | null) => {
+        return text?.split('\uFFFF')
+          .map(text =>
+            text.startsWith('\uFFFE')
+              ? slots[text.replace('\uFFFE', '')]!(translation.value.attributes)
+              : text,
+          )
       }
-      else if (node.nodeType === 1) { // Node.ELEMENT_NODE
-        const el = node as Element
 
-        return h(
-          el.nodeName.toLowerCase(),
-          {
-            ...Object.fromEntries(
-              Array.from(el.attributes).map(attr => [attr.name, attr.value]),
-            ),
-          },
-          Array.from(el.childNodes).map(node => processNode(node)))
+      // No way to type this properly, so we'll just use `any` for now.
+      const processNode = (node: SimpleNode): any => {
+        if (node.nodeType === 3) { // Node.TEXT_NODE
+          return insertSlots(node.nodeValue)
+        }
+        else if (node.nodeType === 1) { // Node.ELEMENT_NODE
+          const el = node as Element
+
+          return h(
+            el.nodeName.toLowerCase(),
+            {
+              ...Object.fromEntries(
+                Array.from(el.attributes).map(attr => [attr.name, attr.value]),
+              ),
+            },
+            Array.from(el.childNodes).map(node => processNode(node)))
+        }
+
+        // Ignore other node types for now.
+        warn(`Unsupported node type: ${(node as any).nodeType}. If you need support for it, please, create an issue in fluent-vue repository.`)
+        return []
       }
 
-      // Ignore other node types for now.
-      warn(`Unsupported node type: ${(node as any).nodeType}. If you need support for it, please, create an issue in fluent-vue repository.`)
-      return []
-    }
+      const children = computed(() => {
+        // If the message value doesn't contain any markup nor any HTML entities, return it as-is.
+        if (!props.html || !reMarkup.test(translation.value.value))
+          return insertSlots(translation.value.value)
 
-    const children = computed(() => {
-      // If the message value doesn't contain any markup nor any HTML entities, return it as-is.
-      if (!props.html || !reMarkup.test(translation.value.value))
-        return insertSlots(translation.value.value)
+        // Otherwise, parse the message value as HTML and convert it to an array of VNodes.
+        const nodes = fluent.options.parseMarkup(translation.value.value)
+        return nodes.map(processNode)
+      })
 
-      // Otherwise, parse the message value as HTML and convert it to an array of VNodes.
-      const nodes = fluent.options.parseMarkup(translation.value.value)
-      return nodes.map(processNode)
-    })
-
-    return () => h(props.tag, { ...attrs }, children.value)
-  },
-})
+      return () => props.tag === false ? children.value : h(props.tag, { ...attrs }, children.value)
+    },
+  })
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the Contributing Guide.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In Vue 3 components do not require a root HTML element.

This pull request allows passing `:tag="false"` or `no-tag` attributes, that disable creation of extra wrapper element.
Added `componentTag` configuration option that sets default value for `tag` attribute of `i18n` component.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes #794


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
