### PR TITLE
Fix stale translations on locale change

### DIFF
--- a/src/composition.ts
+++ b/src/composition.ts
@@ -12,5 +12,5 @@ export function useFluent(): TranslationContext {
   const rootContext = inject(RootContextSymbol)
   assert(rootContext != null, 'useFluent called without installing plugin')
 
-  return getContext(rootContext, instance.proxy)
+  return getContext(rootContext, instance.proxy, true)
 }

--- a/src/getContext.ts
+++ b/src/getContext.ts
@@ -13,6 +13,7 @@ function * flatMap<T, TR>(iterable: Iterable<T>, mapper: (element: T) => TR[]): 
 export function getContext(
   rootContext: TranslationContext,
   instance: VueComponent | null | undefined,
+  fromSetup = false,
 ): TranslationContext {
   if (instance == null)
     return rootContext
@@ -50,7 +51,10 @@ export function getContext(
 
   const context = new TranslationContext(overriddenBundles, rootContext.options)
 
-  options._fluent = context
+  // If we are in script setup, we cannot cache the context
+  // because after component is unmounted, computed will not be updated
+  if (!fromSetup)
+    options._fluent = context
 
   return context
 }

--- a/src/types/vue.d.ts
+++ b/src/types/vue.d.ts
@@ -1,6 +1,6 @@
 import type Vue from 'vue-2'
 import type { FluentResource } from '@fluent/bundle'
-import type { FluentVue } from '../index'
+import type { TranslationContext } from '../TranslationContext'
 
 declare module 'vue-2/types/options' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -8,7 +8,10 @@ declare module 'vue-2/types/options' {
     fluent?: Record<string, FluentResource>
 
     /** @private */
-    _fluent?: FluentVue
+    _fluent?: TranslationContext
+
+    /** @private */
+    _fluentSetup?: TranslationContext
   }
 }
 


### PR DESCRIPTION
### Description

When a component is unmounted, `computed` are not being recalculated, so the cached bundles list becomes stale.

This PR add cache clear on component unmount.

### Linked Issues

https://github.com/orgs/fluent-vue/discussions/834