### PR TITLE
Add support for binding SSR props in Vue 3 directive

### DIFF
--- a/__tests__/utils/ssr.ts
+++ b/__tests__/utils/ssr.ts
@@ -1,0 +1,22 @@
+import * as TestUtils from '@vue/test-utils'
+import type { ComponentOptions } from 'vue-3'
+import { install } from 'vue-demi'
+
+import type { FluentVue } from '../../src'
+
+install()
+
+export function renderSSR<T extends object>(
+  fluent: FluentVue | null,
+  component: ComponentOptions<T>,
+): Promise<string> {
+  const { renderToString } = TestUtils
+
+  const plugins = fluent ? [fluent] : []
+
+  return renderToString(component, {
+    global: {
+      plugins,
+    },
+  })
+}

--- a/__tests__/vue/directive.spec.ts
+++ b/__tests__/vue/directive.spec.ts
@@ -141,6 +141,8 @@ describe('directive', () => {
       `),
     )
 
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
     const component = {
       data: () => ({
         name: 'John',
@@ -153,6 +155,10 @@ describe('directive', () => {
 
     // Assert
     expect(mounted.html()).toEqual('<a aria-label="Hello \u{2068}John\u{2069}">Text</a>')
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(
+      '[fluent-vue] Attribute \'not-allowed\' on element <a> is not localizable. Remove it from the translation. Translation key: link',
+    )
   })
 
   it('works without fallbacks', () => {

--- a/__tests__/vue/ssr.spec.ts
+++ b/__tests__/vue/ssr.spec.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { isVue3 } from 'vue-demi'
+
+import { FluentBundle, FluentResource } from '@fluent/bundle'
+import ftl from '@fluent/dedent'
+
+import { renderSSR } from '../utils/ssr'
+
+import type { FluentVue } from '../../src'
+import { createFluentVue } from '../../src'
+
+describe.skipIf(!isVue3)('sSR directive', () => {
+  let fluent: FluentVue
+  let bundle: FluentBundle
+
+  beforeEach(() => {
+    bundle = new FluentBundle('en-US')
+
+    fluent = createFluentVue({
+      bundles: [bundle],
+    })
+  })
+
+  it('translates text content', async () => {
+    // Arrange
+    bundle.addResource(
+      new FluentResource(ftl`
+      link = Link text
+        .aria-label = Link aria label
+      `),
+    )
+
+    const component = {
+      data: () => ({
+        name: 'John',
+      }),
+      template: '<a v-t:link href="/foo">Fallback text</a>',
+    }
+
+    // Act
+    const rendered = await renderSSR(fluent, component)
+
+    // Assert
+    // This has fallback text because the textContent is not supported by Vue getSSRProps
+    // Text will be translated using directive transform
+    expect(rendered).toEqual('<a href="/foo" aria-label="Link aria label">Fallback text</a>')
+  })
+})

--- a/src/vue/directive.ts
+++ b/src/vue/directive.ts
@@ -63,6 +63,7 @@ export function createVue3Directive(rootContext: TranslationContext): Vue3Direct
           attrs[attr] = attrValue
       }
 
+      // TODO: Include textContent when https://github.com/vuejs/core/issues/8112 is resolved
       return attrs
     },
   }


### PR DESCRIPTION
<!--

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the Contributing Guide.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Bind localized element attributes on server side when using v-t directive.

### Linked Issues

Needed for #695

### Additional context

It only binds attributes, not the text content. This is a limitation of Vue 3, and binding text content will need to be done in the directive transform.

It does not use element type to check whether an attribute is localizable. This is a limitation of Vue 3. To combat potential issues, I have added a runtime warning when translation contains non-localizable attributes.
