### PR TITLE
Implement mergedWith helper method for global translations

### DIFF
--- a/__tests__/globalTranslations.spec.ts
+++ b/__tests__/globalTranslations.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { FluentBundle, FluentResource } from '@fluent/bundle'
+
+import type { FluentVue } from '../src'
+import { createFluentVue } from '../src'
+
+describe('mergedWith', () => {
+  let bundleEn: FluentBundle
+  let bundleUk: FluentBundle
+
+  let fluent: FluentVue
+
+  beforeEach(() => {
+    bundleEn = new FluentBundle('en')
+    bundleUk = new FluentBundle('uk')
+
+    fluent = createFluentVue({
+      bundles: [bundleEn, bundleUk],
+    })
+  })
+
+  it('returns global translations', () => {
+    // Arrange
+    bundleEn.addResource(new FluentResource('hello = Hello, World!'))
+
+    // Act
+    const { $t } = fluent.mergedWith({ en: new FluentResource('hello-two = Hello, World!') })
+    const translation = $t('hello')
+
+    // Assert
+    expect(translation).toEqual('Hello, World!')
+  })
+
+  it('returns merged translation', () => {
+    // Arrange
+    bundleEn.addResource(new FluentResource('hello = Hello, World!'))
+
+    // Act
+    const { $t } = fluent.mergedWith({ en: new FluentResource('hello-two = Hello, World merged!') })
+    const translation = $t('hello-two')
+
+    // Assert
+    expect(translation).toEqual('Hello, World merged!')
+  })
+
+  it('returns overridden global translations', () => {
+    // Arrange
+    bundleEn.addResource(new FluentResource('hello = Hello, World!'))
+
+    // Act
+    const { $t } = fluent.mergedWith({ en: new FluentResource('hello = Hello, World overridden!') })
+    const translation = $t('hello')
+
+    // Assert
+    expect(translation).toEqual('Hello, World overridden!')
+  })
+
+  it('falls back to the next bundle', () => {
+    // Arrange
+    bundleEn.addResource(new FluentResource('hello = Hello, World!'))
+
+    // Act
+    const { $t } = fluent.mergedWith({ uk: new FluentResource('hello-two = Привіт, Світ!') })
+    const translation = $t('hello-two')
+
+    // Assert
+    expect(translation).toEqual('Привіт, Світ!')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import './types/volar'
-import type { FluentBundle, FluentVariable } from '@fluent/bundle'
+import type { FluentBundle, FluentResource, FluentVariable } from '@fluent/bundle'
 import { isVue3, shallowRef } from 'vue-demi'
 import type { FluentVueOptions } from './types'
 
@@ -8,7 +8,7 @@ import type { TranslationWithAttrs } from './TranslationContext'
 import { TranslationContext } from './TranslationContext'
 import { createVue2Directive, createVue3Directive } from './vue/directive'
 import { createComponent } from './vue/component'
-import { getContext } from './getContext'
+import { getContext, getMergedContext } from './getContext'
 import { RootContextSymbol } from './symbols'
 import { resolveOptions } from './util/options'
 
@@ -23,6 +23,11 @@ export interface FluentVue {
   formatAttrs: (key: string, value?: Record<string, FluentVariable>) => Record<string, string>
 
   formatWithAttrs: (key: string, value?: Record<string, FluentVariable>) => TranslationWithAttrs
+
+  mergedWith: (extraTranslations?: Record<string, FluentResource>) => TranslationContext
+
+  $t: (key: string, value?: Record<string, FluentVariable>) => string
+  $ta: (key: string, value?: Record<string, FluentVariable>) => Record<string, string>
 
   install: InstallFunction
 }
@@ -47,9 +52,16 @@ export function createFluentVue(options: FluentVueOptions): FluentVue {
       bundles.value = value
     },
 
+    mergedWith: (extraTranslations?: Record<string, FluentResource>) => {
+      return getMergedContext(rootContext, extraTranslations)
+    },
+
     format: rootContext.format.bind(rootContext),
     formatAttrs: rootContext.formatAttrs.bind(rootContext),
     formatWithAttrs: rootContext.formatWithAttrs.bind(rootContext),
+
+    $t: rootContext.format.bind(rootContext),
+    $ta: rootContext.formatAttrs.bind(rootContext),
 
     install(vue) {
       if (isVue3) {


### PR DESCRIPTION
<!--

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the Contributing Guide.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds `mergedWith` helper method on the global `fluentVue` instance. It simplifies the logic of adding new translations without mutating global translations.
