### PR TITLE
Fix types: i18n component ‘tag’ prop can also be boolean ‘false’

### DIFF
--- a/src/types/volar.ts
+++ b/src/types/volar.ts
@@ -20,7 +20,7 @@ type ComponentType = DefineComponent<{
    * The tag to use as a root element.
    */
   tag: {
-    type: StringConstructor
+    type: PropType<string | false>
     default: 'span'
   }
   /**


### PR DESCRIPTION
Passing ‘:tag=false’ to the i18n component renders no tag, but
TypeScript would complain, since the prop type was defined to allow
only strings.

Widen the type to also allow boolean ‘false’, which matches runtime
behaviour and docs.
