### PR TITLE
Re-export FluentVueOptions type

### DIFF
--- a/.changeset/cuddly-suits-remain.md
+++ b/.changeset/cuddly-suits-remain.md
@@ -1,0 +1,5 @@
+---
+"fluent-vue": patch
+---
+
+Make `FluentVueOptions` type available from `fluent-vue` import

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export type CustomVariableTypes
     ? CustomVariables
     : never
 
+export type { FluentVueOptions }
+
 export interface FluentVue {
   /** Current negotiated fallback chain of languages */
   bundles: Iterable<FluentBundle>


### PR DESCRIPTION
<!--

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the Contributing Guide.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Make `FluentVueOptions` type available from `fluent-vue` import

### Linked Issues

Closes #995

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
