### PR TITLE
Scope Renovate so it never majors the Vue 2 catalog into Vue 3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,18 @@
     {
       "matchPackageNames": ["eslint", "@antfu/eslint-config"],
       "groupName": "eslint packages"
+    },
+    {
+      "description": "vue2 pnpm catalog tracks the Vue 2 line; never propose major bumps (e.g. @vue/test-utils v1 → v2 is a Vue 3 release).",
+      "matchDepTypes": ["pnpm.catalog.vue2"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "vue-2 alias in the vue3 catalog is the Vue 2 peer used for cross-version tests; pin to the v2 major.",
+      "matchDepNames": ["vue-2"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Block major updates inside `pnpm.catalog.vue2` so Renovate can't propose Vue-3-line releases on deps pinned to the Vue 2 line. This is what produced #1013 (`@vue/test-utils` `^1.3.5` → `^2.0.0` — v2 is the Vue 3 release).
- Block major updates on the `vue-2` alias key in the `vue3` catalog. It's `npm:vue@^2.7.16` used as the Vue 2 peer for cross-version tests, so it must stay on the v2 major.

The `vue2` catalog is matched via the `pnpm.catalog.vue2` depType that Renovate generates for each pnpm catalog. Minor and patch updates within the Vue 2 line still flow as before; only major bumps are filtered.

## Test plan

- [ ] Close #1013 (and confirm Renovate does not reopen it on its next run).
- [ ] Confirm the next Renovate run still produces minor/patch updates inside the `vue2` catalog (e.g. `vue@^2.7.x`) when releases land.
- [ ] Confirm Renovate still proposes major bumps for non-Vue-2 deps elsewhere in the repo.