### PR TITLE
Remove unsupported --provenance flag from release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm build && changeset publish --provenance"
+    "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^9.0.0",


### PR DESCRIPTION
## Summary

- `changeset publish` does not accept a `--provenance` flag, so the `Release` workflow has been failing on every push to `main` since #997 with `error Unknown flag for publish: --provenance`.
- Drop the flag from the root `release` script.
- Provenance is still produced automatically: the workflow has `id-token: write` and publishes via npm trusted publishing (the run logs `No NPM_TOKEN found, but OIDC is available — using npm trusted publishing`). npm 11.x (shipped with Node 24, which the setup action uses) auto-generates provenance attestations for trusted-publishing publishes, so no replacement flag or env var is needed.

## Test plan

- [ ] Wait for the `Release` workflow to run on `main` after merge and confirm it succeeds.
- [ ] On the next real release (when a changeset is consumed), verify the published version on npmjs.com shows the **Provenance** badge. If it doesn't, add `NPM_CONFIG_PROVENANCE: true` to the `changesets/action` env block as a follow-up.