### PR TITLE
Align unplugin-fluent-vue exports field with tsdown .mjs/.cjs filenames

### DIFF
--- a/packages/unplugin-fluent-vue/package.json
+++ b/packages/unplugin-fluent-vue/package.json
@@ -29,8 +29,8 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
       },
       "require": {
         "types": "./dist/index.d.cts",
@@ -40,8 +40,8 @@
     "./*": "./*",
     "./rollup": {
       "import": {
-        "types": "./dist/rollup.d.ts",
-        "default": "./dist/rollup.js"
+        "types": "./dist/rollup.d.mts",
+        "default": "./dist/rollup.mjs"
       },
       "require": {
         "types": "./dist/rollup.d.cts",
@@ -50,8 +50,8 @@
     },
     "./vite": {
       "import": {
-        "types": "./dist/vite.d.ts",
-        "default": "./dist/vite.js"
+        "types": "./dist/vite.d.mts",
+        "default": "./dist/vite.mjs"
       },
       "require": {
         "types": "./dist/vite.d.cts",
@@ -60,8 +60,8 @@
     },
     "./webpack": {
       "import": {
-        "types": "./dist/webpack.d.ts",
-        "default": "./dist/webpack.js"
+        "types": "./dist/webpack.d.mts",
+        "default": "./dist/webpack.mjs"
       },
       "require": {
         "types": "./dist/webpack.d.cts",
@@ -70,8 +70,8 @@
     },
     "./nuxt": {
       "import": {
-        "types": "./dist/nuxt.d.ts",
-        "default": "./dist/nuxt.js"
+        "types": "./dist/nuxt.d.mts",
+        "default": "./dist/nuxt.mjs"
       },
       "require": {
         "types": "./dist/nuxt.d.cts",
@@ -80,8 +80,8 @@
     }
   },
   "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.mts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

- The May 16 tsup→tsdown switch (`613844b`) changed dist filenames from `.js`/`.d.ts` to `.mjs`/`.d.mts` but didn't update `exports.import` entries (or top-level `module`/`types`) in `packages/unplugin-fluent-vue/package.json`.
- ESM consumers importing the unplugin's subpath exports (`unplugin-fluent-vue/vite`, `/rollup`, `/webpack`, `/nuxt`) hit `ERR_MODULE_NOT_FOUND` because the `exports` field points at files that don't exist on disk.
- This wasn't caught earlier because no in-workspace consumer was importing the unplugin by its package name. Surfaced while wiring the docs site into the monorepo (vitepress config imports `unplugin-fluent-vue/vite`).

## Test plan

- [ ] In a fresh checkout: \`pnpm install && pnpm build\` produces the same dist files (no build change, only `package.json` exports field changed).
- [ ] Importing \`unplugin-fluent-vue/vite\` from an ESM consumer resolves \`dist/vite.mjs\` instead of failing with \`ERR_MODULE_NOT_FOUND\`.
- [ ] Existing CJS consumers (e.g. webpack via \`require('unplugin-fluent-vue/webpack')\`) keep resolving \`dist/webpack.cjs\` — no change to the \`require\` blocks.