### PR TITLE
Align Renovate and pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 1440 # minutes = 1 day
+
 shellEmulator: true
 strictPeerDependencies: false
 autoInstallPeers: false # Why pnpm? Why?

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
   "ignorePresets": [":ignoreModulesAndTests"],
   "semanticCommits": "disabled",
+  "minimumReleaseAge": "1 day",
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {


### PR DESCRIPTION
## Why

`pnpm install --frozen-lockfile` in CI can fail with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` when Renovate bumps a dependency to a version published inside pnpm's release-age cooldown window. Renovate doesn't know about the cooldown, so it writes a too-fresh version into the lockfile and CI rejects it.

## What

Coordinate the two settings at a 1-day window so they never disagree:

- **`pnpm-workspace.yaml`** — `minimumReleaseAge: 1440` (minutes). Lives in the repo so Renovate's own pnpm runs, including `lockFileMaintenance`, honor it and resolve to appropriately-aged versions.
- **`renovate.json`** — `"minimumReleaseAge": "1 day"`. Renovate holds a branch/PR until the release ages past the window (defaults `internalChecksFilter=strict`), so a too-fresh version never reaches CI.

Values measured from the same npm publish timestamp, and Renovate only opens the PR after the window passes, so matching them exactly at 1 day leaves no skew gap.